### PR TITLE
Properly escape query string in request URLs

### DIFF
--- a/cogs/google.py
+++ b/cogs/google.py
@@ -2,7 +2,7 @@ import discord
 from discord.ext import commands
 from cogs.utils.checks import *
 import aiohttp
-from urllib.parse import parse_qs
+import urllib.parse
 from lxml import etree
 
 '''Module for google web and image search.'''
@@ -150,7 +150,7 @@ class Google:
         """Google web search. Ex: >g what is discordapp?"""
         if not embed_perms(ctx.message):
             config = load_optional_config()
-            async with aiohttp.get("https://www.googleapis.com/customsearch/v1?q=" + query.replace(' ', '+') + "&start=" + '1' + "&key=" + config['google_api_key'] + "&cx=" + config['custom_search_engine']) as resp:
+            async with aiohttp.get("https://www.googleapis.com/customsearch/v1?q=" + urllib.parse.quote_plus(query) + "&start=" + '1' + "&key=" + config['google_api_key'] + "&cx=" + config['custom_search_engine']) as resp:
                 result = json.loads(await resp.text())
             return await self.bot.send_message(ctx.message.channel, result['items'][0]['link'])
         try:
@@ -184,7 +184,7 @@ class Google:
             query = query[1:]
         else:
             item = 0
-        async with aiohttp.get("https://www.googleapis.com/customsearch/v1?q=" + query.replace(' ', '+') + "&start=" + '1' + "&key=" + config['google_api_key'] + "&cx=" + config['custom_search_engine'] + "&searchType=image") as resp:
+        async with aiohttp.get("https://www.googleapis.com/customsearch/v1?q=" + urllib.parse.quote_plus(query) + "&start=" + '1' + "&key=" + config['google_api_key'] + "&cx=" + config['custom_search_engine'] + "&searchType=image") as resp:
             if resp.status != 200:
                 await self.bot.send_message(ctx.message.channel, 'Google failed to respond.')
             result = json.loads(await resp.text())


### PR DESCRIPTION
This ensures that results are returned if special characters (such as `%`) are used for the `>g` and `>i` commands.