### PR TITLE
Improvements to >info command

### DIFF
--- a/cogs/userinfo.py
+++ b/cogs/userinfo.py
@@ -41,13 +41,18 @@ class Userinfo:
                 em.add_field(name='Nick', value=user.nick, inline=True)
                 em.add_field(name='Status', value=user.status, inline=True)
                 em.add_field(name='In Voice', value=user.voice_channel, inline=True)
+                em.add_field(name='Game', value=user.game, inline=True)
+                role = user.top_role.name
+                if role == "@everyone":
+                    role = "N/A"
+                em.add_field(name='Highest Role', value=role, inline=True)
                 em.add_field(name='Account Created', value=user.created_at.__format__('%A, %d. %B %Y @ %H:%M:%S'))
                 em.add_field(name='Join Date', value=user.joined_at.__format__('%A, %d. %B %Y @ %H:%M:%S'))
                 em.set_thumbnail(url=avi)
                 em.set_author(name=user, icon_url='https://i.imgur.com/RHagTDg.png')
                 await self.bot.send_message(ctx.message.channel, embed=em)
             else:
-                msg = '**User Info:** ```User ID: %s\nNick: %s\nStatus: %s\nIn Voice: %s\nAccount Created: %s\nJoin Date: %s\nAvatar url:%s```' % (user.id, user.nick, user.status, user.voice_channel, user.created_at.__format__('%A, %d. %B %Y @ %H:%M:%S'), user.joined_at.__format__('%A, %d. %B %Y @ %H:%M:%S'), avi)
+                msg = '**User Info:** ```User ID: %s\nNick: %s\nStatus: %s\nIn Voice: %s\nGame: %s\nHighest Role: %s\nAccount Created: %s\nJoin Date: %s\nAvatar url:%s```' % (user.id, user.nick, user.status, user.voice_channel, user.game, role, user.created_at.__format__('%A, %d. %B %Y @ %H:%M:%S'), user.joined_at.__format__('%A, %d. %B %Y @ %H:%M:%S'), avi)
                 await self.bot.send_message(ctx.message.channel, bot_prefix + msg)
 
             await self.bot.delete_message(ctx.message)

--- a/cogs/userinfo.py
+++ b/cogs/userinfo.py
@@ -30,8 +30,8 @@ class Userinfo:
                 user = ctx.message.author
 
             # Thanks to IgneelDxD for help on this
-            if user.avatar_url[60:].startswith('a_'):
-                avi = 'https://images.discordapp.net/avatars/' + user.avatar_url[33:][:18] + user.avatar_url[59:-3] + 'gif'
+            if user.avatar_url[54:].startswith('a_'):
+                avi = 'https://images.discordapp.net/avatars/' + user.avatar_url[35:-10]
             else:
                 avi = user.avatar_url
 
@@ -74,8 +74,8 @@ class Userinfo:
             user = ctx.message.author
 
         # Thanks to IgneelDxD for help on this
-        if user.avatar_url[60:].startswith('a_'):
-            avi = 'https://images.discordapp.net/avatars/' + user.avatar_url[33:][:18] + user.avatar_url[59:-3] + 'gif'
+        if user.avatar_url[54:].startswith('a_'):
+            avi = 'https://images.discordapp.net/avatars/' + user.avatar_url[35:-10]
         else:
             avi = user.avatar_url
         if embed_perms(ctx.message):


### PR DESCRIPTION
This PR extends `>info` to display the currently playing game and highest role of the user on the server, and also allows animated avatars to show up properly in their full animated glory (previous offsets were incorrect).

Due to an oddity in how Discord rewrites the URL of embedded images (which, I suspect, has got to do with their server-side image scanning), animated avatars displayed with `>info avi` will be smaller than static avatars.