### PR TITLE
Added forced space for bot prefix

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -206,7 +206,7 @@ class Utility:
                 fp.seek(0)
                 fp.truncate()
                 json.dump(opt, fp, indent=4)
-            self.bot.bot_prefix = msg
+            self.bot.bot_prefix = msg + ' '
             await self.bot.send_message(ctx.message.channel, self.bot.bot_prefix + 'Prefix changed.')
         else:
             await self.bot.send_message(ctx.message.channel, self.bot.bot_prefix + 'Type a prefix as an argument for the `prefix` command')


### PR DESCRIPTION
Wasn't putting the space for some reason, simple fix though