### PR TITLE
Some improvements around the >imagedump command

### DIFF
--- a/cogs/imagedump.py
+++ b/cogs/imagedump.py
@@ -26,7 +26,7 @@ class Imagedump:
                         if item['url'].endswith(i.strip()):
                             yield item['url']
 
-        elif message.embeds:
+        if message.embeds:
             for data in message.embeds:
                 try:
                     url = data['thumbnail']['url']
@@ -37,19 +37,18 @@ class Imagedump:
                 except:
                     pass
 
-        else:
-            urls = []
-            try:
-                urls = re.findall('http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', message.content)
-            except:
-                pass
+        urls = []
+        try:
+            urls = re.findall('http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\(\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+', message.content)
+        except:
+            pass
 
-            if urls is not []:
-                for url in urls:
-                    if url.endswith(('.jpg', '.jpeg', '.png', '.gif', '.gifv', '.webm')) and url not in images:
-                        for i in type_of_items:
-                            if url.endswith(i.strip()):
-                                yield url
+        if urls is not []:
+            for url in urls:
+                if url.endswith(('.jpg', '.jpeg', '.png', '.gif', '.gifv', '.webm')) and url not in images:
+                    for i in type_of_items:
+                        if url.endswith(i.strip()):
+                            yield url
 
     @commands.group(pass_context=True)
     async def imagedump(self, ctx):

--- a/cogs/imagedump.py
+++ b/cogs/imagedump.py
@@ -24,7 +24,7 @@ class Imagedump:
                 if item['url'] != '' and item['url'] not in images:
                     for i in type_of_items:
                         if item['url'].endswith(i.strip()):
-                            return item['url']
+                            yield item['url']
 
         elif message.embeds:
             for data in message.embeds:
@@ -33,7 +33,7 @@ class Imagedump:
                     if (url.endswith(('.jpg', '.jpeg', '.png', '.gif', '.gifv', '.webm')) or data['type'] in {'jpg', 'jpeg', 'png', 'gif', 'gifv', 'webm', 'image'}) and url not in images:
                         for i in type_of_items:
                             if url.endswith(i.strip()):
-                                return url
+                                yield url
                 except:
                     pass
 
@@ -49,9 +49,7 @@ class Imagedump:
                     if url.endswith(('.jpg', '.jpeg', '.png', '.gif', '.gifv', '.webm')) and url not in images:
                         for i in type_of_items:
                             if url.endswith(i.strip()):
-                                return url
-
-        return None
+                                yield url
 
     @commands.group(pass_context=True)
     async def imagedump(self, ctx):
@@ -267,13 +265,12 @@ class Imagedump:
                     print('Fetching last %s messages...' % str(limit-1))
                 async for message in self.bot.logs_from(channel, limit=limit, before=before, after=after):
                     if message.author == user or not user:
-                        url = self.check_images(message, images, type_of_items)
+                        for url in self.check_images(message, images, type_of_items):
+                            if url:
+                                images.append(url)
 
-                        if url:
-                            images.append(url)
-
-                        if len(images) == limit_images:
-                            break
+                            if len(images) == limit_images:
+                                break
 
                 with open('cogs/utils/urls{}.txt'.format(new_dump), 'w') as fp:
                     for url in images:


### PR DESCRIPTION
The `Imagedump.check_message` method previously only returned the first URL it found in a message, this behaviour was replaced by using a generator yielding the URLs instead of returning them.  

It is now also possible to download images from attachments, embeds and URLs should a message have multiple of those.