### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+LICENSE
+README.md
+run.bat
+run_linuxmac.sh
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,60 @@
+FROM python:3.6.2-alpine
+
+WORKDIR app
+COPY requirements.txt /app/requirements.txt
+
+# build dependencies
+RUN \
+apk add --update --no-cache --virtual=build-deps \
+    ca-certificates \
+    freetype-dev \
+    g++ \
+    gcc \
+    lcms2-dev \
+    libffi-dev \
+    libjpeg-turbo-dev \
+    libwebp-dev \
+    libxml2-dev \
+    libxslt-dev \
+    linux-headers \
+    make \
+    tcl-dev \
+    tiff-dev \
+    tk-dev \
+    zlib-dev && \
+
+# runtime dependencies
+apk add --update --no-cache \
+    freetype \
+    lcms2 \
+    libjpeg-turbo \
+    libwebp \
+    libxml2 \
+    libxslt \
+    openjpeg \
+    su-exec \
+    tiff && \
+
+# pip packages
+pip install --no-cache-dir -U \
+    pip && \
+pip install --no-cache-dir -r \
+    requirements.txt && \
+
+# cleanup
+apk del --purge \
+    build-deps && \
+rm -rf \
+    /tmp/*
+
+COPY . /app/
+# move these user modifiable folders so we can copy them to the volume mounts later
+# no way to do these in a single layer unfortunately
+COPY cogs /app/.sample/cogs
+COPY settings /app/.sample/settings
+COPY anims /app/.sample/anims
+
+VOLUME /app/cogs /app/settings /app/anims
+ENTRYPOINT ["./docker-entrypoint.sh"]
+CMD ["python", "-u", "loopself.py"]
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# create our user and run the bot as that user
+USER_ID=${UID:-1234}
+GROUP_ID=${GID:-1234}
+
+adduser -S -u $USER_ID -g $GROUP_ID selfbot
+chown selfbot /app
+chown selfbot /app/*
+
+# move the original files back to the correct location as
+# they have been mounted as volumes on the host filesystem
+cp -rf /app/.sample/* /app/
+
+# run bot as the selfbot user
+su-exec selfbot "$@"
+


### PR DESCRIPTION
Adds files necessary to build/run a Docker container of the bot. I'll be hanging around in the discord if anyone has any questions about this PR or docker itself. However, I don't recommend merging this PR until custom cogs have it's own separate folder (it's coming right?) and I change some stuff to fit that.

Some additional details: there are 3 "user editable" folders, namely, `cogs`, `settings`, and `anims`. These folders are mapped to a location on the host system. Since we are not running as `root`, we need to provide docker with the UID and GID of the user who owns those aforementioned folders or the container will shit itself.

So to run the bot with docker: 
```sh
docker run --name=selfbot \
        -e UID=<uid> -e GID=<gid> \
        -v <path to cogs folder>:/app/cogs \
        -v <path to settings folder>:/app/settings \
        -v <path to anims folder>:/app/anims \
        duckness/discord-selfbot:latest
```

Additional notes:
You may want interactive input for the first run of the bot (to input your discord token, etc), add the `-it` flag to the command above. Otherwise, putting your existing settings into the mapped folder should work as well.