### PR TITLE
Fix for iOS mobile embed link on the REPL cog

### DIFF
--- a/cogs/repl.py
+++ b/cogs/repl.py
@@ -129,8 +129,8 @@ class EmbedShell():
 
                 self.repl_embeds[shell].add_field(
                             name="`>>> {}`".format(cleaned),
-                            value="[`Exited. History for latest session: "
-                                  "View on Hastebin.`]({})".format(
+                            value="[Exited. History for latest session: "
+                                  "View on Hastebin.]({})".format(
                                 haste_url),
                             inline=False)
 
@@ -220,8 +220,8 @@ class EmbedShell():
                         haste_url = await hastebin(str(fmt), self.bot.session)
                         self.repl_embeds[shell].add_field(
                             name="`>>> {}`".format(cleaned),
-                            value="[`Content too big to be printed. "
-                                  "Hosted on Hastebin.`]({})".format(
+                            value="[Content too big to be printed. "
+                                  "Hosted on Hastebin.]({})".format(
                                 haste_url),
                             inline=False)
 


### PR DESCRIPTION
Fixes an iOS mobile bug where links wrapped in ticks don't work - this removes them, making it clickable. Regular embed links work fine (that bug was fixed), but not bold links or any links wrapped in ticks that are inside embeds. This fixes it so the Hastebin URL is clickable on iOS devices using the mobile app with the repl/embed shell.