### PR TITLE
Version pin yarl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyfiglet==0.7.5
 tokage==1.0.0
 pytz==2017.2
 PyGithub==1.34
+yarl<1.2


### PR DESCRIPTION
Yarl interferes with the required aiohttp version for rewrite. This pins yarl to the latest version where it works with aiohttp.