### PR TITLE
Fix cog list command

### DIFF
--- a/appuselfbot.py
+++ b/appuselfbot.py
@@ -24,8 +24,11 @@ from cogs.utils.allmsgs import custom, quickcmds
 from cogs.utils.webhooks import Webhook
 from cogs.utils.checks import *
 from cogs.utils.config import *
+from collections import namedtuple
 from discord.ext import commands
 
+
+FakeGuild = namedtuple("FakeGuild", ["name", "id", "icon_url", "members", "me", "channels", "emojis"])
 
 def parse_cmd_arguments():  # allows for arguments
     parser = argparse.ArgumentParser(description="Discord-Selfbot")
@@ -727,6 +730,7 @@ async def on_message(message):
         except (AttributeError, discord.errors.HTTPException):
             pass
 
+    
     await bot.process_commands(message)
 
 

--- a/cogs/cog_download.py
+++ b/cogs/cog_download.py
@@ -1,4 +1,4 @@
-﻿import discord
+import discord
 import os
 import requests
 import pip
@@ -29,7 +29,7 @@ class CogDownloading:
     @commands.group(pass_context=True)
     async def cog(self, ctx):
         """Manage custom cogs from ASCII. [p]help cog for more information.
-        
+
         The Appu Selfbot Cog Importable Index (aka ASCII) is a server that hosts custom cogs for the bot.
         [p]cog install <cog> - Install a custom cog from ASCII.
         [p]cog uninstall <cog> - Uninstall one of your ASCII cogs.
@@ -133,7 +133,9 @@ class CogDownloading:
             list_.append(a.get("title"))
         installed = []
         uninstalled = []
-        for entry in list_[3:]:
+        for entry in list_:
+            if entry is None or not entry.endswith(".json"):
+                continue
             response = requests.get("https://lyricly.github.io/ASCII/cogs/{}".format(entry))
             found_cog = response.json()
             filename = found_cog["link"].rsplit("/",1)[1].rsplit(".",1)[0]

--- a/cogs/cog_download.py
+++ b/cogs/cog_download.py
@@ -128,12 +128,12 @@ class CogDownloading:
         site = requests.get('https://github.com/LyricLy/ASCII/tree/master/cogs').text
         soup = BeautifulSoup(site, "lxml")
         data = soup.find_all(attrs={"class": "js-navigation-open"})
-        list = []
+        list_ = []
         for a in data:
-            list.append(a.get("title"))
+            list_.append(a.get("title"))
         installed = []
         uninstalled = []
-        for entry in list[2:]:
+        for entry in list_[3:]:
             response = requests.get("https://lyricly.github.io/ASCII/cogs/{}".format(entry))
             found_cog = response.json()
             filename = found_cog["link"].rsplit("/",1)[1].rsplit(".",1)[0]

--- a/cogs/track.py
+++ b/cogs/track.py
@@ -29,7 +29,7 @@ class Track:
 
     async def register_command(self, ctx):
         if self.bot.track:
-            async with self.bot.session.post(self.url + "/command", data={"command_name": ctx.command.name, "guild_id": str(ctx.guild.id), "guild_name": ctx.guild.name}) as resp:
+            async with self.bot.session.post(self.url + "/command", data={"command_name": ctx.command.name, "guild_id": str(ctx.guild.id) if ctx.guild else str(ctx.channel.recipient.id), "guild_name": ctx.guild.name}) as resp:
                 pass
 
     async def heartbeat(self):


### PR DESCRIPTION
Just a quick fix for the cog list command which was failing on my system.

Instead of just assuming how many entries to skip in "list_", just ignore any None entries and anything that doesn't end with ".json". This should fix any changes that BS returns in the future if the structure of the page changes. For the most part anyway, unless github decides to completely overhaul things. 