### PR TITLE
Update Dockerfile to properly install lxml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM python:3.6.5
 ADD . /Discord-Selfbot
 
 RUN cd Discord-Selfbot && \


### PR DESCRIPTION
Lxml does not properly install when building on the latest python version. Changing the python version to 3.6.5 fixes this issue.